### PR TITLE
getUserLanguage fix when not running in browser

### DIFF
--- a/packages/modal/src/utils.ts
+++ b/packages/modal/src/utils.ts
@@ -14,7 +14,7 @@ export const languageMap = {
 export const getUserLanguage = (defaultLanguage: string | undefined) => {
   let userLanguage = defaultLanguage;
   if (!userLanguage) {
-    const browserLanguage = (window.navigator as NavigatorLanguage).userLanguage || window.navigator.language || "en-US";
+    const browserLanguage = typeof window !== undefined ? (window.navigator as NavigatorLanguage).userLanguage || window.navigator.language || "en-US" : "en-US";
     userLanguage = browserLanguage.split("-")[0];
   }
   return Object.prototype.hasOwnProperty.call(languageMap, userLanguage) ? userLanguage : "en";


### PR DESCRIPTION
* Fixed error on function `getUserLanguage`
    * the function was referencing `window` without checking its value which resulted in `ReferenceError: window is not defined` when not running in a browser.