### PR TITLE
fix solflare msg signing response

### DIFF
--- a/packages/providers/solana-provider/src/providers/injectedProviders/solflare/providerHandlers.ts
+++ b/packages/providers/solana-provider/src/providers/injectedProviders/solflare/providerHandlers.ts
@@ -21,5 +21,10 @@ export const getSolflareHandlers = (injectedProvider: SolflareWallet, getProvide
     const res = await conn.sendRawTransaction(transaction.serialize());
     return { signature: res };
   };
+
+  solflareProviderHandlers.signMessage = async (req: JRPCRequest<{ message: Uint8Array; display?: "utf8" | "hex" }>): Promise<Uint8Array> => {
+    const sigData = await injectedProvider.signMessage(req.params.message, req.params.display);
+    return sigData;
+  };
   return solflareProviderHandlers;
 };


### PR DESCRIPTION
- Solflare sdk returns signed msg directly rather than an object which is contradictory to their docs.

https://docs.solflare.com/solflare/technical/deeplinks/provider-methods/signmessage#returns