### PR TITLE
Don't print error if metamask provider is not available

### DIFF
--- a/packages/adapters/metamask-adapter/src/metamaskAdapter.ts
+++ b/packages/adapters/metamask-adapter/src/metamaskAdapter.ts
@@ -58,7 +58,7 @@ class MetamaskAdapter extends BaseEvmAdapter<void> {
   async init(options: AdapterInitOptions = {}): Promise<void> {
     await super.init(options);
     super.checkInitializationRequirements();
-    this.metamaskProvider = (await detectEthereumProvider({ mustBeMetaMask: true })) as EthereumProvider;
+    this.metamaskProvider = (await detectEthereumProvider({ mustBeMetaMask: true, silent: true })) as EthereumProvider;
     if (!this.metamaskProvider) throw WalletInitializationError.notInstalled("Metamask extension is not installed");
     this.status = ADAPTER_STATUS.READY;
     this.emit(ADAPTER_EVENTS.READY, WALLET_ADAPTERS.METAMASK);


### PR DESCRIPTION
Before 
<img width="575" alt="image" src="https://github.com/Web3Auth/web3auth-web/assets/16631641/0957a7b3-6a6b-49de-9e94-6fb193e7e228">

After
<img width="801" alt="image" src="https://github.com/Web3Auth/web3auth-web/assets/16631641/ee45472e-fd61-4341-aa20-86c4e846d6bd">
