### PR TITLE
fix: set signMethods

### DIFF
--- a/packages/providers/ethereum-mpc-provider/src/providers/signingProviders/EthereumSigningProvider.ts
+++ b/packages/providers/ethereum-mpc-provider/src/providers/signingProviders/EthereumSigningProvider.ts
@@ -89,6 +89,7 @@ export class EthereumSigningProvider extends BaseProvider<
     this.updateProviderEngineProxy(provider);
     await txFormatter.init();
     await this.lookupNetwork();
+    this.state.signMethods = { sign, getPublic };
   }
 
   public async updateAccount(params: {


### PR DESCRIPTION
Ethereum mpc provider is not setting the state.signMethods during setupProvider.
This state is checked during switchChain and switchAccount

Assign state.signMethods at the end of setupProvider