### PR TITLE
Add default ui mode for No Modal SDK

### DIFF
--- a/packages/no-modal/src/noModal.ts
+++ b/packages/no-modal/src/noModal.ts
@@ -127,6 +127,7 @@ export class Web3AuthNoModal extends SafeEventEmitter implements IWeb3Auth {
 
         const { whitelabel } = projectConfig;
         this.coreOptions.uiConfig = merge(clonedeep(whitelabel), this.coreOptions.uiConfig);
+        if (!this.coreOptions.uiConfig.mode) this.coreOptions.uiConfig.mode = "light";
 
         const { sms_otp_enabled: smsOtpEnabled, whitelist } = projectConfig;
         if (smsOtpEnabled !== undefined) {


### PR DESCRIPTION
For consistency between no modal and modal ui configs, adding in the default mode within the no modal sdk as light mode.