### PR TITLE
Fix: Convert defaultOtherModalConfig to function instead of object.

### DIFF
--- a/packages/modal/src/config.ts
+++ b/packages/modal/src/config.ts
@@ -80,7 +80,7 @@ export const defaultEvmWalletModalConfig: AdaptersModalConfig = {
   },
 };
 
-export const defaultOtherModalConfig = (): AdaptersModalConfig => ({
+export const defaultOtherModalConfig = {
   chainNamespace: CHAIN_NAMESPACES.OTHER,
   adapters: {
     [EVM_ADAPTERS.OPENLOGIN]: {
@@ -90,4 +90,4 @@ export const defaultOtherModalConfig = (): AdaptersModalConfig => ({
       showOnDesktop: true,
     },
   },
-});
+};

--- a/packages/modal/src/config.ts
+++ b/packages/modal/src/config.ts
@@ -80,7 +80,7 @@ export const defaultEvmWalletModalConfig: AdaptersModalConfig = {
   },
 };
 
-export const defaultOtherModalConfig: AdaptersModalConfig = {
+export const defaultOtherModalConfig = (): AdaptersModalConfig => ({
   chainNamespace: CHAIN_NAMESPACES.OTHER,
   adapters: {
     [EVM_ADAPTERS.OPENLOGIN]: {
@@ -90,4 +90,4 @@ export const defaultOtherModalConfig: AdaptersModalConfig = {
       showOnDesktop: true,
     },
   },
-};
+});

--- a/packages/modal/src/config.ts
+++ b/packages/modal/src/config.ts
@@ -80,7 +80,7 @@ export const defaultEvmWalletModalConfig: AdaptersModalConfig = {
   },
 };
 
-export const defaultOtherModalConfig = {
+export const defaultOtherModalConfig: AdaptersModalConfig = {
   chainNamespace: CHAIN_NAMESPACES.OTHER,
   adapters: {
     [EVM_ADAPTERS.OPENLOGIN]: {

--- a/packages/modal/src/modalManager.ts
+++ b/packages/modal/src/modalManager.ts
@@ -52,7 +52,7 @@ export class Web3Auth extends Web3AuthNoModal implements IWeb3AuthModal {
 
   readonly options: Web3AuthOptions;
 
-  private modalConfig: AdaptersModalConfig = defaultOtherModalConfig();
+  private modalConfig: AdaptersModalConfig = clonedeep(defaultOtherModalConfig);
 
   constructor(options: Web3AuthOptions) {
     super(options);

--- a/packages/modal/src/modalManager.ts
+++ b/packages/modal/src/modalManager.ts
@@ -52,7 +52,7 @@ export class Web3Auth extends Web3AuthNoModal implements IWeb3AuthModal {
 
   readonly options: Web3AuthOptions;
 
-  private modalConfig: AdaptersModalConfig = defaultOtherModalConfig;
+  private modalConfig: AdaptersModalConfig = defaultOtherModalConfig();
 
   constructor(options: Web3AuthOptions) {
     super(options);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


Jira Link:


## Description
<!--- Describe your changes in detail -->
Whenever create new WebAuth object, modal config adapters keep remaining of previous object.
https://github.com/user-attachments/assets/8cd66b04-cca3-4b5d-8dc2-db4ae8ae62fd

Root cause: defaultOtherModalConfig when assign to modalConfig use reference instead of value.
Solution: convert defaultOtherModalConfig to function.


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
