### PR TITLE
composable - prevent web3auth init loop in watcher

### DIFF
--- a/packages/composables/modal-vue-composables/src/Web3AuthProvider.ts
+++ b/packages/composables/modal-vue-composables/src/Web3AuthProvider.ts
@@ -99,9 +99,9 @@ export const Web3AuthProvider = defineComponent({
     };
 
     watch(
-      [web3Auth, () => props.config],
-      () => {
-        if (web3Auth.value) return;
+      [() => props.config],
+      (_newConfig, _oldConfig, onCleanup) => {
+        // if (web3Auth.value) return;
 
         const resetHookState = () => {
           provider.value = null;

--- a/packages/composables/modal-vue-composables/src/Web3AuthProvider.ts
+++ b/packages/composables/modal-vue-composables/src/Web3AuthProvider.ts
@@ -100,7 +100,7 @@ export const Web3AuthProvider = defineComponent({
 
     watch(
       [() => props.config],
-      (_newConfig, _oldConfig, onCleanup) => {
+      () => {
         // if (web3Auth.value) return;
 
         const resetHookState = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
modal vue composable watcher is making web3auth init looping

Jira Link:


## Description
<!--- Describe your changes in detail -->
prevent the loop by setting the watcher to only watch config


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
