### PR TITLE
check aaProvider when sending aaConfig to wallet-service

### DIFF
--- a/packages/plugins/wallet-services-plugin/src/plugin.ts
+++ b/packages/plugins/wallet-services-plugin/src/plugin.ts
@@ -100,6 +100,7 @@ export class WalletServicesPlugin extends SafeEventEmitter implements IPlugin {
     if (!connectedChainConfig.tickerName) throw WalletServicesPluginError.invalidParams("tickerName is required in chainConfig");
 
     const enableAccountAbstraction =
+      web3auth.coreOptions.accountAbstractionProvider &&
       web3auth.coreOptions.useAAWithExternalWallet &&
       (web3auth.connectedAdapterName === WALLET_ADAPTERS.AUTH ||
         (web3auth.connectedAdapterName !== WALLET_ADAPTERS.AUTH && web3auth.coreOptions.useAAWithExternalWallet));

--- a/packages/plugins/wallet-services-plugin/src/plugin.ts
+++ b/packages/plugins/wallet-services-plugin/src/plugin.ts
@@ -101,7 +101,6 @@ export class WalletServicesPlugin extends SafeEventEmitter implements IPlugin {
 
     const enableAccountAbstraction =
       web3auth.coreOptions.accountAbstractionProvider &&
-      web3auth.coreOptions.useAAWithExternalWallet &&
       (web3auth.connectedAdapterName === WALLET_ADAPTERS.AUTH ||
         (web3auth.connectedAdapterName !== WALLET_ADAPTERS.AUTH && web3auth.coreOptions.useAAWithExternalWallet));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
Send aaConfig as undefined when there is on accountAbstractionProvider
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Jira Link:
https://toruslabs.atlassian.net/browse/PD-4056

## Description
<!--- Describe your changes in detail -->


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Screenshot 2024-12-05 at 12 16 20 PM](https://github.com/user-attachments/assets/db98df36-595c-4529-b84a-801145662671)
![Screenshot 2024-12-05 at 12 17 37 PM](https://github.com/user-attachments/assets/f1d43a7d-7eba-4b0c-8a6e-194c4e574161)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My code requires a db migration.
