### PR TITLE
fix issue of switching custom chains in injected wallet

### DIFF
--- a/packages/adapters/default-evm-adapter/src/injectedEvmAdapter.ts
+++ b/packages/adapters/default-evm-adapter/src/injectedEvmAdapter.ts
@@ -71,6 +71,7 @@ class InjectedEvmAdapter extends BaseEvmAdapter<void> {
   async connect(): Promise<IProvider | null> {
     super.checkConnectionRequirements();
     if (!this.injectedProvider) throw WalletLoginError.connectionError("Injected provider is not available");
+    if (!this.chainConfig) throw WalletLoginError.connectionError("Chain config is not available");
     this.status = ADAPTER_STATUS.CONNECTING;
     this.emit(ADAPTER_EVENTS.CONNECTING, { adapter: this.name });
     try {
@@ -85,15 +86,10 @@ class InjectedEvmAdapter extends BaseEvmAdapter<void> {
         }
       }
       this.status = ADAPTER_STATUS.CONNECTED;
-      const chainDisconnectHandler = () => {
-        this.disconnect();
-        if (this.injectedProvider.removeListener) this.injectedProvider.removeListener("disconnect", chainDisconnectHandler);
-      };
-      this.injectedProvider.on("disconnect", chainDisconnectHandler);
       const accountDisconnectHandler = (accounts: string[]) => {
         if (accounts.length === 0) {
           this.disconnect();
-          if (this.injectedProvider.removeListener) this.injectedProvider.removeListener("accountsChanged", accountDisconnectHandler);
+          if (this.injectedProvider?.removeListener) this.injectedProvider.removeListener("accountsChanged", accountDisconnectHandler);
         }
       };
       this.injectedProvider.on("accountsChanged", accountDisconnectHandler);
@@ -114,6 +110,7 @@ class InjectedEvmAdapter extends BaseEvmAdapter<void> {
   }
 
   async disconnect(options: { cleanup: boolean } = { cleanup: false }): Promise<void> {
+    if (!this.injectedProvider) throw WalletLoginError.connectionError("Injected provider is not available");
     await super.disconnectSession();
     if (typeof this.injectedProvider?.removeAllListeners !== "undefined") this.injectedProvider?.removeAllListeners();
     try {

--- a/packages/adapters/default-evm-adapter/src/injectedEvmAdapter.ts
+++ b/packages/adapters/default-evm-adapter/src/injectedEvmAdapter.ts
@@ -112,7 +112,7 @@ class InjectedEvmAdapter extends BaseEvmAdapter<void> {
   async disconnect(options: { cleanup: boolean } = { cleanup: false }): Promise<void> {
     if (!this.injectedProvider) throw WalletLoginError.connectionError("Injected provider is not available");
     await super.disconnectSession();
-    if (typeof this.injectedProvider?.removeAllListeners !== "undefined") this.injectedProvider?.removeAllListeners();
+    if (typeof this.injectedProvider.removeAllListeners !== "undefined") this.injectedProvider.removeAllListeners();
     try {
       await this.injectedProvider.request({
         method: "wallet_revokePermissions",
@@ -135,8 +135,9 @@ class InjectedEvmAdapter extends BaseEvmAdapter<void> {
   }
 
   public async addChain(chainConfig: CustomChainConfig, init = false): Promise<void> {
+    if (!this.injectedProvider) throw WalletLoginError.connectionError("Injected provider is not available");
     super.checkAddChainRequirements(chainConfig, init);
-    await this.injectedProvider?.request({
+    await this.injectedProvider.request({
       method: "wallet_addEthereumChain",
       params: [
         {
@@ -157,8 +158,9 @@ class InjectedEvmAdapter extends BaseEvmAdapter<void> {
   }
 
   public async switchChain(params: { chainId: string }, init = false): Promise<void> {
+    if (!this.injectedProvider) throw WalletLoginError.connectionError("Injected provider is not available");
     super.checkSwitchChainRequirements(params, init);
-    await this.injectedProvider?.request({
+    await this.injectedProvider.request({
       method: "wallet_switchEthereumChain",
       params: [{ chainId: params.chainId }],
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Jira Link: https://toruslabs.atlassian.net/browse/PD-4391


## Description
<!--- Describe your changes in detail -->
When connecting to injected provider (Metamask), it fails to switch back and forth among custom chains. I found that during switching custom chains, Metamask fire event "disconnect" which indicates unavailable RPC network and this only happens to custom chains. We should not treat this event as a truly disconnect signal and only rely on accountsChanged event to detect if dapp is disconnected from wallets.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/f4739562-a43f-40de-8b59-43dfee8c5274)
![image](https://github.com/user-attachments/assets/5ff12289-a802-4ee2-b382-f5a17a0c1ba8)
![image](https://github.com/user-attachments/assets/25a71dd1-a3b5-45c5-83a6-24ad5328ef10)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My code requires a db migration.
