### PR TITLE
fix issue with provider event re-emitting for WS provider

### DIFF
--- a/packages/no-modal/src/connectors/wallet-connect-v2-connector/config.ts
+++ b/packages/no-modal/src/connectors/wallet-connect-v2-connector/config.ts
@@ -31,6 +31,14 @@ export enum DEFAULT_SOLANA_EVENTS {
   SOL_ACCOUNTS_CHANGED = "accountsChanged",
 }
 
+export enum EIP1193_EVENTS {
+  ACCOUNTS_CHANGED = "accountsChanged",
+  CHAIN_CHANGED = "chainChanged",
+  CONNECT = "connect",
+  DISCONNECT = "disconnect",
+  MESSAGE = "message",
+}
+
 export const SOLANA_CAIP_CHAIN_MAP: Record<string, string> = {
   "0x65": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
   "0x66": "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z",

--- a/packages/no-modal/src/connectors/wallet-connect-v2-connector/config.ts
+++ b/packages/no-modal/src/connectors/wallet-connect-v2-connector/config.ts
@@ -31,14 +31,6 @@ export enum DEFAULT_SOLANA_EVENTS {
   SOL_ACCOUNTS_CHANGED = "accountsChanged",
 }
 
-export enum EIP1193_EVENTS {
-  ACCOUNTS_CHANGED = "accountsChanged",
-  CHAIN_CHANGED = "chainChanged",
-  CONNECT = "connect",
-  DISCONNECT = "disconnect",
-  MESSAGE = "message",
-}
-
 export const SOLANA_CAIP_CHAIN_MAP: Record<string, string> = {
   "0x65": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
   "0x66": "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z",

--- a/packages/no-modal/src/providers/base-provider/baseProvider.ts
+++ b/packages/no-modal/src/providers/base-provider/baseProvider.ts
@@ -10,6 +10,7 @@ import {
   WalletInitializationError,
   WalletProviderError,
 } from "@/core/base";
+import { EIP1193_EVENTS } from "@/core/wallet-connect-v2-connector";
 
 import { BaseProviderEvents } from "./interfaces";
 
@@ -119,13 +120,24 @@ export abstract class BaseProvider<C extends BaseProviderConfig, S extends BaseP
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (this._providerEngineProxy as any).setTarget(provider);
       // re-emit events from provider
-      this._providerEngineProxy.eventNames().forEach((event) => {
+      const providerEvents = new Set([
+        EIP1193_EVENTS.CHAIN_CHANGED,
+        EIP1193_EVENTS.ACCOUNTS_CHANGED,
+        EIP1193_EVENTS.CONNECT,
+        EIP1193_EVENTS.DISCONNECT,
+        EIP1193_EVENTS.MESSAGE,
+        ...this._providerEngineProxy.eventNames(),
+      ]);
+      providerEvents.forEach((event) => {
         provider.on(event as keyof ProviderEvents, (...args) => {
+          if (event === EIP1193_EVENTS.CHAIN_CHANGED) {
+            // update chainId state
+            this.update({ chainId: (args as string[])[0] } as Partial<S>);
+          }
           // eslint-disable-next-line
           this.emit(event as keyof BaseProviderEvents<S>, ...(args as any));
         });
       });
-      this.handleChainChangedProvider();
     } else {
       this._providerEngineProxy = createEventEmitterProxy<SafeEventEmitterProvider>(provider);
     }
@@ -145,13 +157,6 @@ export abstract class BaseProvider<C extends BaseProviderConfig, S extends BaseP
 
   protected getChain(chainId: string): CustomChainConfig {
     return this.config.chains.find((chain) => chain.chainId === chainId);
-  }
-
-  private handleChainChangedProvider() {
-    // This is only added because we don't have ethereum and solana private key providers anymore
-    this.provider.on("chainChanged", (chainId: string) => {
-      this.update({ chainId } as Partial<S>);
-    });
   }
 
   abstract setupProvider(provider: P, chainId: string): Promise<void>;

--- a/packages/no-modal/src/providers/base-provider/baseProvider.ts
+++ b/packages/no-modal/src/providers/base-provider/baseProvider.ts
@@ -10,9 +10,9 @@ import {
   WalletInitializationError,
   WalletProviderError,
 } from "@/core/base";
-import { EIP1193_EVENTS } from "@/core/wallet-connect-v2-connector";
 
 import { BaseProviderEvents } from "./interfaces";
+import { EIP1193_EVENTS } from "./utils";
 
 export interface BaseProviderState extends BaseState {
   chainId: string;

--- a/packages/no-modal/src/providers/base-provider/interfaces.ts
+++ b/packages/no-modal/src/providers/base-provider/interfaces.ts
@@ -2,4 +2,7 @@ import { BaseControllerEvents } from "@toruslabs/base-controllers";
 
 import { ProviderEvents } from "@/core/base";
 
-export type BaseProviderEvents<S> = ProviderEvents & BaseControllerEvents<S>;
+export type BaseProviderEvents<S> = ProviderEvents &
+  BaseControllerEvents<S> & {
+    newListener: (event: string, listener: (...args: unknown[]) => void) => void;
+  };

--- a/packages/no-modal/src/providers/base-provider/utils.ts
+++ b/packages/no-modal/src/providers/base-provider/utils.ts
@@ -1,4 +1,12 @@
 import getCreateRandomId from "json-rpc-random-id";
 export const createRandomId = getCreateRandomId();
 
+export enum EIP1193_EVENTS {
+  ACCOUNTS_CHANGED = "accountsChanged",
+  CHAIN_CHANGED = "chainChanged",
+  CONNECT = "connect",
+  DISCONNECT = "disconnect",
+  MESSAGE = "message",
+}
+
 export { getED25519Key } from "@web3auth/auth";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Jira Link:


## Description
<!--- Describe your changes in detail -->
we want events to propagate from Ethereum provider -> wrapper provider (e.g. CommonJRPC provider) -> SDK -> dapp
when a listener is added to the wrapper provider, listen to the same event from the Ethereum provider and re-emit it

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
- for embedded wallets, can switch between EVM chains, Solana chains and different chain namespaces
![image](https://github.com/user-attachments/assets/1587478b-5b2d-40fa-a74f-296d273f2f11)
![image](https://github.com/user-attachments/assets/cee943b4-4876-412b-b289-3622e5138d95)
![image](https://github.com/user-attachments/assets/39a7ab84-e476-4287-bbc6-69a70c0a1b01)
![image](https://github.com/user-attachments/assets/9bf18d50-fd74-43d0-b203-6f0691365327)

- for external wallets, can switch between EVM chains
![image](https://github.com/user-attachments/assets/50d322e0-70a3-4eb5-86cc-187177ee79fd)
![image](https://github.com/user-attachments/assets/8b654c96-235a-4747-9966-99499e0581a3)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My code requires a db migration.
