### PR TITLE
fix empty modal when only metamask is active

### DIFF
--- a/packages/modal/src/ui/components/Widget/Widget.tsx
+++ b/packages/modal/src/ui/components/Widget/Widget.tsx
@@ -120,10 +120,15 @@ function Widget(props: WidgetProps) {
     () => isEmailPasswordLessLoginVisible || isSmsPasswordLessLoginVisible,
     [isEmailPasswordLessLoginVisible, isSmsPasswordLessLoginVisible]
   );
-  const showExternalWalletButton = useMemo(() => modalState.hasExternalWallets, [modalState]);
+  const showExternalWalletButton = useMemo(
+    () => modalState.hasExternalWallets || !!modalState.externalWalletsConfig[WALLET_CONNECTORS.METAMASK],
+    [modalState]
+  );
   const showExternalWalletPage = useMemo(
-    () => (areSocialLoginsVisible || showPasswordLessInput) && !modalState.externalWalletsVisibility,
-    [areSocialLoginsVisible, showPasswordLessInput, modalState.externalWalletsVisibility]
+    () =>
+      (areSocialLoginsVisible || showPasswordLessInput || !!modalState.externalWalletsConfig[WALLET_CONNECTORS.METAMASK]) &&
+      !modalState.externalWalletsVisibility,
+    [areSocialLoginsVisible, showPasswordLessInput, modalState]
   );
 
   const handleExternalWalletBtnClick = (flag: boolean) => {

--- a/packages/modal/src/ui/loginModal.tsx
+++ b/packages/modal/src/ui/loginModal.tsx
@@ -297,11 +297,12 @@ export class LoginModal {
     options?: { externalWalletsInitialized: boolean; externalWalletsVisibility: boolean; showExternalWalletsOnly: boolean }
   ): void => {
     this.externalWalletsConfig = externalWalletsConfig;
+    const isMMAvailable = !!externalWalletsConfig[WALLET_CONNECTORS.METAMASK];
     this.setState({
       externalWalletsConfig,
       externalWalletsInitialized: !!options.externalWalletsInitialized,
       showExternalWalletsOnly: !!options.showExternalWalletsOnly,
-      externalWalletsVisibility: !!options.externalWalletsVisibility,
+      externalWalletsVisibility: isMMAvailable ? false : !!options.externalWalletsVisibility,
     });
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes web3auth-modal not showing any connectors when metamask is only active

Jira Link:


## Description
<!--- Describe your changes in detail -->


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
**Before**
<img width="1646" height="770" alt="image" src="https://github.com/user-attachments/assets/97c5ad73-752d-41ca-a956-00d89cfbe5c8" />
<img width="660" height="718" alt="image" src="https://github.com/user-attachments/assets/f7225797-2b45-4f1e-a23e-9e62769d1f79" />

**After**
<img width="404" height="541" alt="Screenshot 2025-07-10 at 10 00 24 PM" src="https://github.com/user-attachments/assets/3aa31afb-68ba-4340-a140-479fb702ccc6" />



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code requires a db migration.
