### PR TITLE
fixes external wallet autoconnect if no in-app connectors are enabled

### DIFF
--- a/packages/modal/src/modalManager.ts
+++ b/packages/modal/src/modalManager.ts
@@ -322,9 +322,10 @@ export class Web3Auth extends Web3AuthNoModal implements IWeb3AuthModal {
     // initialize connectors based on availability
     const { hasInAppConnectors, hasExternalConnectors } = await this.checkConnectorAvailability(filteredConnectorNames);
     const filteredConnectors = connectors.filter((x) => filteredConnectorNames.includes(x.name as WALLET_CONNECTOR_TYPE));
-    if (hasInAppConnectors) {
-      await this.initInAppAndCachedConnectors(filteredConnectors);
-    }
+
+    // initialize in-app and cached connector (if there are only external connectors enabled)
+    await this.initInAppAndCachedConnectors(filteredConnectors);
+
     if (hasExternalConnectors) {
       if (hasInAppConnectors) {
         // show connect button if both in-app and external wallets are available


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Jira Link: https://consensyssoftware.atlassian.net/browse/W3APD-4967

Issue Description:

- If a `dapp` only has external connectors enabled, then autoconnect doesn't works.
- It can be reproduced on https://v10-demo.vercel.app/

## Description
<!--- Describe your changes in detail -->

- Enables `initInAppAndCachedConnectors` if there are no in-app connectors.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

QA tested this.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My code requires a db migration.
