### PR TITLE
Fix: set correct type of icon url passed to Metamask SDK

### DIFF
--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -84,7 +84,7 @@ class MetaMaskConnector extends BaseEvmConnector<void> {
     const appMetadata: MetaMaskSDKOptions["dappMetadata"] = {
       name: getSiteName(window) || "web3auth",
       url: window.location.origin || "https://web3auth.io",
-      iconUrl,
+      iconUrl: iconUrl ?? undefined,
     };
 
     // initialize the MetaMask SDK

--- a/packages/no-modal/src/connectors/utils.ts
+++ b/packages/no-modal/src/connectors/utils.ts
@@ -44,7 +44,7 @@ function imgExists(url: string): Promise<boolean> {
 /**
  * Extracts an icon for the site from the DOM
  */
-export async function getSiteIcon(window: Window): Promise<string | null> {
+export async function getSiteIcon(window: Window): Promise<string | undefined> {
   const { document } = window;
 
   // Use the site's favicon if it exists
@@ -59,7 +59,7 @@ export async function getSiteIcon(window: Window): Promise<string | null> {
     return icon.href;
   }
 
-  return null;
+  return undefined;
 }
 
 export function parseToken<T>(token: string): { header: { alg: string; typ: string; kid?: string }; payload: T } {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Jira Link: https://consensyssoftware.atlassian.net/browse/W3APD-5089


## Description
<!--- Describe your changes in detail -->
When we open the DApp in mobile browser and login web3auth using metamask, getting deeplink error, and metamaks isn't opening.
<img width="720" height="1600" alt="image" src="https://github.com/user-attachments/assets/d5ccd2fb-cc9c-4115-bae0-08892c583e8f" />

- It's not allowed to pass NULL as iconURL to Metamask SDK
https://github.com/MetaMask/metamask-mobile/blob/main/app/core/DeeplinkManager/parseOriginatorInfo.ts#L68

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code requires a db migration.
